### PR TITLE
Refactor list and search logic to commands/playlist.py

### DIFF
--- a/src/commands/playlist.py
+++ b/src/commands/playlist.py
@@ -1,8 +1,10 @@
-from typing import List
+from typing import List, Generator, Optional, Any
 import spotipy
+import concurrent.futures
 from rich.console import Console
 
 console = Console()
+err_console = Console(stderr=True)
 
 def move_tracks(sp: spotipy.Spotify, track_uris: List[str], source_id: str, dest_id: str):
     """
@@ -40,3 +42,56 @@ def add_tracks(sp: spotipy.Spotify, track_uris: List[str], playlist_id: str):
         sp.playlist_add_items(playlist_id, batch)
         
     console.print(f"[green]Successfully added {len(track_uris)} tracks.[/]")
+
+def get_playlist_tracks(sp: spotipy.Spotify, playlist_id: str) -> Generator[dict, None, None]:
+    """
+    Yields tracks from a playlist.
+    Handles pagination automatically.
+    """
+    results = sp.playlist_tracks(playlist_id)
+    while results:
+        for item in results['items']:
+            if item['track']:  # Can be None for local/unavailable tracks
+                yield item['track']
+        results = sp.next(results) if results.get('next') else None
+
+def _search_worker(sp: spotipy.Spotify, line: str) -> Optional[dict]:
+    """
+    Helper function to search for a single track.
+    Returns track dict or None.
+    """
+    line = line.strip()
+    if not line:
+        return None
+
+    # Parse "Artist - Title" format
+    if " - " not in line:
+        err_console.print(f"[yellow]Skipping invalid format:[/] {line}")
+        return None
+
+    artist, title = line.split(" - ", 1)
+    try:
+        result = sp.search(q=f'artist:{artist} track:{title}', type='track', limit=1)
+
+        if result['tracks']['items']:
+            return result['tracks']['items'][0]
+        else:
+            err_console.print(f"[red]Not found:[/] {artist} - {title}")
+            return None
+    except Exception as e:
+        err_console.print(f"[red]Error searching for:[/] {line} - {str(e)}")
+        return None
+
+def search_tracks(sp: spotipy.Spotify, lines: List[str]) -> Generator[Optional[dict], None, None]:
+    """
+    Search for tracks in parallel.
+    Yields found track objects (or None) in order.
+    """
+    # Use ThreadPoolExecutor for parallel processing
+    # Limit workers to avoid rate limits
+    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+        # Submit all tasks and preserve order
+        futures = [executor.submit(_search_worker, sp, line) for line in lines]
+
+        for future in futures:
+            yield future.result()

--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,15 @@
 import typer
 import sys
-import concurrent.futures
 from pathlib import Path
 from typing import Optional
 from rich.console import Console
 from .spotify_client import get_spotify
-from .commands.playlist import move_tracks as do_move_tracks
+from .commands.playlist import (
+    move_tracks as do_move_tracks,
+    add_tracks as do_add_tracks,
+    get_playlist_tracks,
+    search_tracks
+)
 
 
 app = typer.Typer(help="Swedish Army Knife for Spotify actions.")
@@ -58,29 +62,6 @@ def move(
     except Exception as e:
         err_console.print(f"[bold red]Move Failed:[/] {str(e)}")
 
-def _search_worker(sp, line: str):
-    line = line.strip()
-    if not line:
-        return None
-
-    # Parse "Artist - Title" format
-    if " - " not in line:
-        err_console.print(f"[yellow]Skipping invalid format:[/] {line}")
-        return None
-
-    artist, title = line.split(" - ", 1)
-    try:
-        result = sp.search(q=f'artist:{artist} track:{title}', type='track', limit=1)
-
-        if result['tracks']['items']:
-            return result['tracks']['items'][0]
-        else:
-            err_console.print(f"[red]Not found:[/] {artist} - {title}")
-            return None
-    except Exception as e:
-        err_console.print(f"[red]Error searching for:[/] {line} - {str(e)}")
-        return None
-
 @playlist_app.command(name="search")
 def search(
     output: str = typer.Option("uri", "--output", "-o", help="Output format: uri (default), id, text")
@@ -98,22 +79,15 @@ def search(
     
     lines = sys.stdin.readlines()
 
-    # Use ThreadPoolExecutor for parallel processing
-    # Limit workers to avoid rate limits
-    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
-        # Submit all tasks and preserve order
-        futures = [executor.submit(_search_worker, sp, line) for line in lines]
-        
-        for future in futures:
-            track = future.result()
-            if track:
-                if output == "id":
-                    print(track['id'])
-                elif output == "text":
-                    artists = ', '.join([a['name'] for a in track['artists']])
-                    print(f"{artists} - {track['name']}")
-                else:
-                    print(track['uri'])
+    for track in search_tracks(sp, lines):
+        if track:
+            if output == "id":
+                print(track['id'])
+            elif output == "text":
+                artists = ', '.join([a['name'] for a in track['artists']])
+                print(f"{artists} - {track['name']}")
+            else:
+                print(track['uri'])
 
 @playlist_app.command(name="list")
 def list_tracks(
@@ -137,19 +111,14 @@ def list_tracks(
     
     try:
         sp = get_spotify()
-        results = sp.playlist_tracks(playlist_id)
-        while results:
-            for item in results['items']:
-                track = item['track']
-                if track:  # Can be None for local/unavailable tracks
-                    if output == "id":
-                        print(track['id'])
-                    elif output == "uri":
-                        print(track['uri'])
-                    else:
-                        artists = ', '.join([a['name'] for a in track['artists']])
-                        print(f"{artists} - {track['name']}")
-            results = sp.next(results) if results.get('next') else None
+        for track in get_playlist_tracks(sp, playlist_id):
+            if output == "id":
+                print(track['id'])
+            elif output == "uri":
+                print(track['uri'])
+            else:
+                artists = ', '.join([a['name'] for a in track['artists']])
+                print(f"{artists} - {track['name']}")
     except Exception as e:
         err_console.print(f"[bold red]Error:[/] {str(e)}")
         raise typer.Exit(1)
@@ -162,7 +131,6 @@ def add_tracks_to_playlist(
 ):
     """Add tracks to a playlist. Reads track URIs from file or stdin."""
     import re
-    from .commands.playlist import add_tracks as do_add_tracks
 
     # 1. Resolve Playlist ID
     if url:
@@ -204,4 +172,3 @@ def add_tracks_to_playlist(
 
 if __name__ == "__main__":
     app()
-

--- a/task.md
+++ b/task.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] List Tracks — Export playlist contents as `Artist - Title` lines
+- [x] Search Tracks — Find Spotify URIs from `Artist - Title` input
+- [x] Add Tracks — Batch add tracks to playlists
+- [x] Move Tracks — Bulk move tracks between playlists
+- [x] Refactor CLI commands to separate logic from `src/main.py`

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -9,6 +9,9 @@ runner = CliRunner()
 def mock_consoles(mocker):
     mock_console = mocker.patch("src.main.console")
     mock_err_console = mocker.patch("src.main.err_console")
+    # Also patch the consoles in commands/playlist.py to share the same mock
+    mocker.patch("src.commands.playlist.console", mock_console)
+    mocker.patch("src.commands.playlist.err_console", mock_err_console)
     return mock_console, mock_err_console
 
 def test_status_command(mocker, mock_consoles):


### PR DESCRIPTION
Moves the logic for `list` and `search` commands from `src/main.py` to `src/commands/playlist.py` to adhere to SOLID principles and separate CLI concerns from business logic. Updated `src/main.py` to call the new functions and updated `tests/unit/test_main.py` to mock the correct console instances.

---
*PR created automatically by Jules for task [5889946475836669835](https://jules.google.com/task/5889946475836669835) started by @opbenesh*