### PR TITLE
Refactor playlist commands to separate module

### DIFF
--- a/src/commands/playlist.py
+++ b/src/commands/playlist.py
@@ -1,8 +1,10 @@
 from typing import List
+import concurrent.futures
 import spotipy
 from rich.console import Console
 
 console = Console()
+err_console = Console(stderr=True)
 
 def move_tracks(sp: spotipy.Spotify, track_uris: List[str], source_id: str, dest_id: str):
     """
@@ -40,3 +42,65 @@ def add_tracks(sp: spotipy.Spotify, track_uris: List[str], playlist_id: str):
         sp.playlist_add_items(playlist_id, batch)
         
     console.print(f"[green]Successfully added {len(track_uris)} tracks.[/]")
+
+def _search_worker(sp, line: str):
+    line = line.strip()
+    if not line:
+        return None
+
+    # Parse "Artist - Title" format
+    if " - " not in line:
+        err_console.print(f"[yellow]Skipping invalid format:[/] {line}")
+        return None
+
+    artist, title = line.split(" - ", 1)
+    try:
+        result = sp.search(q=f'artist:{artist} track:{title}', type='track', limit=1)
+
+        if result['tracks']['items']:
+            return result['tracks']['items'][0]
+        else:
+            err_console.print(f"[red]Not found:[/] {artist} - {title}")
+            return None
+    except Exception as e:
+        err_console.print(f"[red]Error searching for:[/] {line} - {str(e)}")
+        return None
+
+def search_tracks(sp: spotipy.Spotify, lines: List[str], output_format: str):
+    """
+    Search for tracks and output their URIs (default), IDs, or Artist - Title.
+    """
+    # Use ThreadPoolExecutor for parallel processing
+    # Limit workers to avoid rate limits
+    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+        # Submit all tasks and preserve order
+        futures = [executor.submit(_search_worker, sp, line) for line in lines]
+
+        for future in futures:
+            track = future.result()
+            if track:
+                if output_format == "id":
+                    print(track['id'])
+                elif output_format == "text":
+                    artists = ', '.join([a['name'] for a in track['artists']])
+                    print(f"{artists} - {track['name']}")
+                else:
+                    print(track['uri'])
+
+def list_playlist_tracks(sp: spotipy.Spotify, playlist_id: str, output_format: str):
+    """
+    List tracks from a playlist. Default output is 'Artist - Title', optionally output URIs or IDs.
+    """
+    results = sp.playlist_tracks(playlist_id)
+    while results:
+        for item in results['items']:
+            track = item['track']
+            if track:  # Can be None for local/unavailable tracks
+                if output_format == "id":
+                    print(track['id'])
+                elif output_format == "uri":
+                    print(track['uri'])
+                else:
+                    artists = ', '.join([a['name'] for a in track['artists']])
+                    print(f"{artists} - {track['name']}")
+        results = sp.next(results) if results.get('next') else None

--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,15 @@
 import typer
 import sys
-import concurrent.futures
 from pathlib import Path
 from typing import Optional
 from rich.console import Console
 from .spotify_client import get_spotify
-from .commands.playlist import move_tracks as do_move_tracks
+from .commands.playlist import (
+    move_tracks as do_move_tracks,
+    add_tracks as do_add_tracks,
+    search_tracks,
+    list_playlist_tracks
+)
 
 
 app = typer.Typer(help="Swedish Army Knife for Spotify actions.")
@@ -58,29 +62,6 @@ def move(
     except Exception as e:
         err_console.print(f"[bold red]Move Failed:[/] {str(e)}")
 
-def _search_worker(sp, line: str):
-    line = line.strip()
-    if not line:
-        return None
-
-    # Parse "Artist - Title" format
-    if " - " not in line:
-        err_console.print(f"[yellow]Skipping invalid format:[/] {line}")
-        return None
-
-    artist, title = line.split(" - ", 1)
-    try:
-        result = sp.search(q=f'artist:{artist} track:{title}', type='track', limit=1)
-
-        if result['tracks']['items']:
-            return result['tracks']['items'][0]
-        else:
-            err_console.print(f"[red]Not found:[/] {artist} - {title}")
-            return None
-    except Exception as e:
-        err_console.print(f"[red]Error searching for:[/] {line} - {str(e)}")
-        return None
-
 @playlist_app.command(name="search")
 def search(
     output: str = typer.Option("uri", "--output", "-o", help="Output format: uri (default), id, text")
@@ -98,22 +79,8 @@ def search(
     
     lines = sys.stdin.readlines()
 
-    # Use ThreadPoolExecutor for parallel processing
-    # Limit workers to avoid rate limits
-    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
-        # Submit all tasks and preserve order
-        futures = [executor.submit(_search_worker, sp, line) for line in lines]
-        
-        for future in futures:
-            track = future.result()
-            if track:
-                if output == "id":
-                    print(track['id'])
-                elif output == "text":
-                    artists = ', '.join([a['name'] for a in track['artists']])
-                    print(f"{artists} - {track['name']}")
-                else:
-                    print(track['uri'])
+    # Delegate logic to command module
+    search_tracks(sp, lines, output)
 
 @playlist_app.command(name="list")
 def list_tracks(
@@ -137,19 +104,7 @@ def list_tracks(
     
     try:
         sp = get_spotify()
-        results = sp.playlist_tracks(playlist_id)
-        while results:
-            for item in results['items']:
-                track = item['track']
-                if track:  # Can be None for local/unavailable tracks
-                    if output == "id":
-                        print(track['id'])
-                    elif output == "uri":
-                        print(track['uri'])
-                    else:
-                        artists = ', '.join([a['name'] for a in track['artists']])
-                        print(f"{artists} - {track['name']}")
-            results = sp.next(results) if results.get('next') else None
+        list_playlist_tracks(sp, playlist_id, output)
     except Exception as e:
         err_console.print(f"[bold red]Error:[/] {str(e)}")
         raise typer.Exit(1)
@@ -162,7 +117,6 @@ def add_tracks_to_playlist(
 ):
     """Add tracks to a playlist. Reads track URIs from file or stdin."""
     import re
-    from .commands.playlist import add_tracks as do_add_tracks
 
     # 1. Resolve Playlist ID
     if url:
@@ -204,4 +158,3 @@ def add_tracks_to_playlist(
 
 if __name__ == "__main__":
     app()
-

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -9,6 +9,9 @@ runner = CliRunner()
 def mock_consoles(mocker):
     mock_console = mocker.patch("src.main.console")
     mock_err_console = mocker.patch("src.main.err_console")
+    # Also patch playlist commands consoles
+    mocker.patch("src.commands.playlist.console", mock_console)
+    mocker.patch("src.commands.playlist.err_console", mock_err_console)
     return mock_console, mock_err_console
 
 def test_status_command(mocker, mock_consoles):


### PR DESCRIPTION
Refactored the `search` and `list` commands to move their implementation details from `src/main.py` to `src/commands/playlist.py`. This change improves code organization by separating CLI entry points from business logic. The `src/main.py` file now delegates the actual work to the `playlist` module.

The refactoring includes:
- Moving `_search_worker` and `search_tracks` logic to `src/commands/playlist.py`.
- Moving `list_playlist_tracks` logic to `src/commands/playlist.py`.
- Updating `src/main.py` to import and call these functions.
- Updating `tests/unit/test_main.py` to correctly mock the `console` and `err_console` instances in `src/commands/playlist.py` ensuring tests pass.

---
*PR created automatically by Jules for task [14032834901524420096](https://jules.google.com/task/14032834901524420096) started by @opbenesh*