### PR TITLE
Strict Mode for Playlist Move

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ sak playlist list --id SOURCE_ID | sak playlist search | sak playlist add --id D
 # From a file
 sak playlist move --file tracks.txt --from SOURCE_ID --to DEST_ID
 
+# Use --strict to only move tracks that actually exist in the source playlist
+sak playlist move --file tracks.txt --from SOURCE_ID --to DEST_ID --strict
+
 # Or pipe URIs directly
 sak playlist list --id SOURCE_ID | sak playlist search | sak playlist move --from SOURCE_ID --to DEST_ID
 ```

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,6 @@
 import typer
 import sys
 import json
-<<<<<<< HEAD
 import concurrent.futures
 from pathlib import Path
 from typing import Optional
@@ -52,9 +51,13 @@ def create(
 def move(
     tracks_file: Optional[Path] = typer.Option(None, "--file", "-f", help="File containing track URIs/IDs, one per line. If not provided, reads from stdin."),
     source: str = typer.Option(..., "--from", "-s", help="Source playlist ID."),
-    dest: str = typer.Option(..., "--to", "-d", help="Destination playlist ID.")
+    dest: str = typer.Option(..., "--to", "-d", help="Destination playlist ID."),
+    strict: bool = typer.Option(False, "--strict", help="Only move tracks that exist in the source playlist.")
 ):
-    """Move tracks from one playlist to another. Reads track URIs from file or stdin."""
+    """Move tracks from one playlist to another. Reads track URIs from file or stdin.
+
+    If --strict is used, it verifies tracks exist in the source playlist before moving.
+    """
     if tracks_file:
         if not tracks_file.exists():
             err_console.print(f"[bold red]Error:[/] File {tracks_file} does not exist.")
@@ -74,7 +77,7 @@ def move(
         
     try:
         sp = get_spotify()
-        do_move_tracks(sp, tracks, source, dest)
+        do_move_tracks(sp, tracks, source, dest, strict=strict)
     except Exception as e:
         err_console.print(f"[bold red]Move Failed:[/] {str(e)}")
 

--- a/task.md
+++ b/task.md
@@ -11,7 +11,6 @@
 - [x] Update `README.md` with new features
 - [x] Complete pre-commit steps
 
-<<<<<<< HEAD
 ## Playlist Management
 - [x] `sak status` - Check connection status
 - [x] `sak playlist list` - List tracks from a playlist
@@ -20,6 +19,7 @@
     - [x] Support `--format json` for metadata
 - [x] `sak playlist add` - Add tracks to a playlist
 - [x] `sak playlist move` - Move tracks between playlists
+    - [x] Support `--strict` mode
 - [x] `sak playlist find` - Look up a playlist ID by its name
 
 ## Internal Improvements

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -199,3 +199,14 @@ def test_create_playlist_command(mocker, mock_consoles):
     assert result.exit_code == 0
     mock_console.print.assert_called_once_with("spotify:playlist:new_id")
     mock_create.assert_called_once_with(mock_spotify.return_value, "New Playlist")
+
+def test_move_command_strict(mocker):
+    mock_move = mocker.patch("src.main.do_move_tracks")
+    mock_spotify = mocker.patch("src.main.get_spotify")
+    mocker.patch("src.main.is_interactive", return_value=False)
+
+    input_tracks = "spotify:track:123"
+    result = runner.invoke(app, ["playlist", "move", "--from", "src_id", "--to", "dst_id", "--strict"], input=input_tracks)
+
+    assert result.exit_code == 0
+    mock_move.assert_called_once_with(mock_spotify.return_value, ["spotify:track:123"], "src_id", "dst_id", strict=True)

--- a/tests/unit/test_playlist_move_strict.py
+++ b/tests/unit/test_playlist_move_strict.py
@@ -1,0 +1,74 @@
+import pytest
+from unittest.mock import MagicMock
+from src.commands.playlist import move_tracks
+
+def test_move_tracks_strict_mode(mocker):
+    sp = MagicMock()
+
+    # Source playlist has tracks 1 and 2
+    # We want to move tracks 2 and 3
+    # Track 3 should be skipped because it's not in the source playlist
+
+    source_id = "source_id"
+    dest_id = "dest_id"
+    input_tracks = ["spotify:track:2", "spotify:track:3"]
+
+    # Mocking playlist_tracks
+    sp.playlist_tracks.return_value = {
+        'items': [
+            {'track': {'uri': 'spotify:track:1'}},
+            {'track': {'uri': 'spotify:track:2'}}
+        ],
+        'next': None
+    }
+
+    # Execute move with strict=True
+    move_tracks(sp, input_tracks, source_id, dest_id, strict=True)
+
+    # Should only add track 2 to destination
+    sp.playlist_add_items.assert_called_once_with(dest_id, ["spotify:track:2"])
+
+    # Should only remove track 2 from source
+    sp.playlist_remove_all_occurrences_of_items.assert_called_once_with(source_id, ["spotify:track:2"])
+
+def test_move_tracks_non_strict_mode(mocker):
+    sp = MagicMock()
+
+    source_id = "source_id"
+    dest_id = "dest_id"
+    input_tracks = ["spotify:track:2", "spotify:track:3"]
+
+    # Execute move with strict=False (default)
+    move_tracks(sp, input_tracks, source_id, dest_id, strict=False)
+
+    # Should add both to destination
+    sp.playlist_add_items.assert_called_once_with(dest_id, ["spotify:track:2", "spotify:track:3"])
+
+    # Should try to remove both from source
+    sp.playlist_remove_all_occurrences_of_items.assert_called_once_with(source_id, ["spotify:track:2", "spotify:track:3"])
+
+def test_move_tracks_strict_mode_with_ids(mocker):
+    sp = MagicMock()
+
+    # Test that it handles IDs by normalizing them to URIs
+    source_id = "source_id"
+    dest_id = "dest_id"
+    input_tracks = ["track2", "track3"]
+
+    # Mocking playlist_tracks returns URIs
+    sp.playlist_tracks.return_value = {
+        'items': [
+            {'track': {'uri': 'spotify:track:track1'}},
+            {'track': {'uri': 'spotify:track:track2'}}
+        ],
+        'next': None
+    }
+
+    # Execute move with strict=True
+    move_tracks(sp, input_tracks, source_id, dest_id, strict=True)
+
+    # Should only add track 2 to destination
+    sp.playlist_add_items.assert_called_once_with(dest_id, ["track2"])
+
+    # Should only remove track 2 from source
+    sp.playlist_remove_all_occurrences_of_items.assert_called_once_with(source_id, ["track2"])


### PR DESCRIPTION
This PR implements a strict mode for the `playlist move` command. 

Previously, `playlist move` would add tracks to the destination playlist even if they were not present in the source playlist (where the removal would silently fail or do nothing). This caused unintended "copy" behavior for tracks that weren't in the source.

The new `--strict` flag ensures that the source playlist is checked before any tracks are added to the destination. Only tracks present in the source are moved.

Key changes:
- Logic for fetching all tracks from a playlist (paginated).
- URI normalization for reliable comparison.
- CLI flag `--strict` for the `move` command.
- Extensive unit tests covering URI/ID normalization and filtering logic.

Fixes #5

---
*PR created automatically by Jules for task [4564220575695990704](https://jules.google.com/task/4564220575695990704) started by @opbenesh*